### PR TITLE
Revert Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 +------------------------------------------------------------------------+
 
-| P R O P A G A N D A   Desktop Enhancements For Linux                   |
+| P R O P A G A N D A   Desktop Enhancements For Linux   by Bowie J.Poag |
 
 +------------------------------------------------------------------------+
+
+  Hello! Thanks for downloading this archive..I hope you get out of it as much as I put into it. :) Propaganda is a pet project of mine--my way of helping the Linux community by drawing attention to the platform, and providing current Linux users (and prospective ones!) with the raw materials they need to customize the appearance of their systems.
+
+  Propaganda, at its core, is basically a collection of "seamless tiles". Graphics which are drawn in such a way that they do not appear to repeat at the edges. All the graphics for Propaganda are drawn with GIMP, an excellent paint program also made available under the GNU GPL. Propaganda tiles are painted in a wide variety of styles, textures and sizes, making them ideal for use in 3D applications, or simply as desktop wallpaper.
+
+  Propaganda tiles can be used freely, provided they are not bundled with a product which violates the GPL. You can download them, use them wherever you like, even give some to a friend. Thats fine -- But personally, my thoughts are with the advancement of Linux as a platform. Propaganda is a way to show the rest of the industry that Linux can be made _as good_ , if not better than a certain unnamed Redmond,WA-based software giant's "operating system". :) Its hoped that Propaganda will attract users to Linux, and help current users at the same time.
+
+If you'de like to drop me a line, or if you have a question regarding something i'm involved with, feel free to do so by emailing me at bowie23@excite.com.
+
+Until then, good luck, and happy hunting. :) And again, thanks for downloading Propaganda.. Its popularity and success come from folks like you.
+
+Bowie J. Poagn
+
+5/15/01
+
+
+*Uploaded 11/30/2016*
+
+*Benjamin Carr*


### PR DESCRIPTION
Removing the `Readme` contents is not in the spirit of Linux, the GPL, or the work that Bowie J. Poagn did to create these tiles. The readme is more a roadmap of hope for the adoption of Linux on the desktop, the fact that the GPL allowed sharing, and almost most importantly that `copyleft` applied to more than just the code.
-B